### PR TITLE
Add helm & ansible setup for k8sinfra with rolldice

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,38 @@
-#HI
+# K8s Infra Helm Setup with Signoz
+
+This repository contains Ansible playbooks to deploy the [k8s-infra](https://github.com/SigNoz/k8s-infra) Helm chart and a sample `rolldice` application. The chart forwards Kubernetes logs to an upstream OpenTelemetry collector (e.g. SigNoz running on TrueNAS).
+
+## Prerequisites
+
+- Kubernetes cluster reachable from the host running Ansible
+- Helm and kubectl configured for the cluster
+- Ansible installed
+- Access to a SigNoz OpenTelemetry collector endpoint
+
+Install required Ansible collections:
+
+```bash
+ansible-galaxy collection install -r ansible/requirements.yml
+```
+
+## Usage
+
+1. Set the collector endpoint by editing `ansible/up.yaml` or passing it on the command line:
+
+```bash
+ansible-playbook ansible/up.yaml -e otel_collector_endpoint=http://collector:4317
+```
+
+2. To remove all deployed resources:
+
+```bash
+ansible-playbook ansible/down.yaml
+```
+
+3. After deployment, generate some telemetry with the helper script:
+
+```bash
+./test.sh
+```
+
+Then open the SigNoz UI to confirm traces and logs from `rolldice` are visible.

--- a/ansible/down.yaml
+++ b/ansible/down.yaml
@@ -1,0 +1,21 @@
+- name: Remove k8sinfra and rolldice
+  hosts: localhost
+  gather_facts: false
+  tasks:
+    - name: Remove rolldice deployment
+      kubernetes.core.k8s:
+        state: absent
+        definition: "{{ lookup('file', '../k8s/rolldice.yaml') }}"
+
+    - name: Uninstall k8sinfra helm chart
+      community.kubernetes.helm:
+        name: k8sinfra
+        release_namespace: k8sinfra
+        state: absent
+
+    - name: Remove k8sinfra namespace
+      kubernetes.core.k8s:
+        api_version: v1
+        kind: Namespace
+        name: k8sinfra
+        state: absent

--- a/ansible/requirements.yml
+++ b/ansible/requirements.yml
@@ -1,0 +1,3 @@
+collections:
+  - name: community.kubernetes
+  - name: kubernetes.core

--- a/ansible/up.yaml
+++ b/ansible/up.yaml
@@ -1,0 +1,29 @@
+- name: Install k8sinfra and rolldice
+  hosts: localhost
+  gather_facts: false
+  vars:
+    otel_collector_endpoint: "http://signoz-collector.truenas:4317"
+  tasks:
+    - name: Render values file
+      template:
+        src: ../values/k8sinfra-values.yaml.j2
+        dest: /tmp/k8sinfra-values.yaml
+
+    - name: Add Signoz helm repo
+      community.kubernetes.helm_repository:
+        name: signoz
+        repo_url: https://charts.signoz.io
+
+    - name: Install k8sinfra helm chart
+      community.kubernetes.helm:
+        name: k8sinfra
+        chart_ref: signoz/k8s-infra
+        release_namespace: k8sinfra
+        create_namespace: true
+        values_files:
+          - /tmp/k8sinfra-values.yaml
+
+    - name: Deploy rolldice app
+      kubernetes.core.k8s:
+        state: present
+        definition: "{{ lookup('file', '../k8s/rolldice.yaml') }}"

--- a/ansible/up.yaml
+++ b/ansible/up.yaml
@@ -2,6 +2,7 @@
   hosts: localhost
   gather_facts: false
   vars:
+    ansible_python_interpreter: /home/codespace/.python/current/bin/python3
     otel_collector_endpoint: "http://signoz-collector.truenas:4317"
   tasks:
     - name: Render values file

--- a/k8s/rolldice.yaml
+++ b/k8s/rolldice.yaml
@@ -2,6 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: rolldice
+  namespace: k8sinfra
   labels:
     app: rolldice
 spec:
@@ -16,7 +17,7 @@ spec:
     spec:
       containers:
         - name: rolldice
-          image: ghcr.io/signoz/rolldice:latest
+          image: nginx:latest
           ports:
             - containerPort: 8080
 ---
@@ -24,6 +25,7 @@ apiVersion: v1
 kind: Service
 metadata:
   name: rolldice
+  namespace: k8sinfra   # <-- Add this line
 spec:
   selector:
     app: rolldice

--- a/k8s/rolldice.yaml
+++ b/k8s/rolldice.yaml
@@ -1,0 +1,33 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: rolldice
+  labels:
+    app: rolldice
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: rolldice
+  template:
+    metadata:
+      labels:
+        app: rolldice
+    spec:
+      containers:
+        - name: rolldice
+          image: ghcr.io/signoz/rolldice:latest
+          ports:
+            - containerPort: 8080
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: rolldice
+spec:
+  selector:
+    app: rolldice
+  ports:
+    - port: 80
+      targetPort: 8080
+  type: NodePort

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+# Simple helper to generate telemetry from rolldice app
+
+set -euo pipefail
+
+kubectl port-forward svc/rolldice 8080:80 &
+PF_PID=$!
+
+# give port-forward time to establish
+sleep 2
+
+# hit the endpoint a few times to produce traces/logs
+for i in {1..5}; do
+  curl -s http://localhost:8080/roll || true
+  sleep 1
+done
+
+kill $PF_PID

--- a/values/k8sinfra-values.yaml.j2
+++ b/values/k8sinfra-values.yaml.j2
@@ -1,0 +1,2 @@
+otelCollector:
+  endpoint: "{{ otel_collector_endpoint }}"


### PR DESCRIPTION
## Summary
- add Ansible playbooks to install/uninstall k8sinfra and rolldice
- template values file to set OTEL collector endpoint
- provide sample rolldice deployment
- update README with instructions and helper script
- include ansible collection requirements and test script

## Testing
- `ansible-playbook --syntax-check ansible/up.yaml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687ad8a02e4083338181046acba104d8